### PR TITLE
Update spamlist to fix false positive match on "specialist"

### DIFF
--- a/config/blacklist.txt
+++ b/config/blacklist.txt
@@ -38,7 +38,7 @@ celexa
 celebrex
 cephalexin
 chloroquine
-cialis
+\bcialis\b
 cipro
 citalopram
 cleocin


### PR DESCRIPTION
The entry for `cialis` is preventing legitimate use of the word `specialist`; added word boundary regex to that entry.